### PR TITLE
Operation mode selector and Temperature sensors

### DIFF
--- a/custom_components/ariston/const.py
+++ b/custom_components/ariston/const.py
@@ -54,6 +54,7 @@ DEFAULT_ENERGY_SCAN_INTERVAL_MINUTES: final = 60
 DEFAULT_BUS_ERRORS_SCAN_INTERVAL_SECONDS: final = 30
 
 ATTR_TARGET_TEMP_STEP: final = "target_temp_step"
+ATTR_HVAC_ACTION: final = "hvac_action"
 ATTR_HEAT_REQUEST: final = "heat_request"
 ATTR_ECONOMY_TEMP: final = "economy_temp"
 ATTR_HOLIDAY: final = "holiday"
@@ -183,6 +184,10 @@ ARISTON_WATER_HEATER_TYPES: list[AristonWaterHeaterEntityDescription] = (
             {
                 EXTRA_STATE_ATTRIBUTE: ATTR_TARGET_TEMP_STEP,
                 EXTRA_STATE_DEVICE_METHOD: lambda entity: entity.device.water_heater_temperature_step,
+            },
+            {
+                EXTRA_STATE_ATTRIBUTE: ATTR_HVAC_ACTION,
+                EXTRA_STATE_DEVICE_METHOD: lambda entity: "heating" if entity.device.is_heating else "idle",
             }
         ],
         device_features=[CustomDeviceFeatures.HAS_DHW],
@@ -323,6 +328,22 @@ ARISTON_SENSOR_TYPES: list[AristonSensorEntityDescription] = (
         coordinator=ENERGY_COORDINATOR,
         get_native_value=lambda entity: entity.device.central_heating_total_energy_consumption,
         get_last_reset=lambda entity: entity.device.consumption_sequence_last_changed_utc,
+    ),
+    AristonSensorEntityDescription(
+        key="Target temperature",
+        name=f"{NAME} Target temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        get_native_value=lambda entity: int(entity.device.water_heater_target_temperature),
+        get_native_unit_of_measurement=lambda entity: entity.device.water_heater_temperature_unit,
+    ),
+    AristonSensorEntityDescription(
+        key="Current temperature",
+        name=f"{NAME} Current temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        get_native_value=lambda entity: int(entity.device.water_heater_current_temperature),
+        get_native_unit_of_measurement=lambda entity: entity.device.water_heater_temperature_unit,
     ),
     AristonSensorEntityDescription(
         key="Domestic hot water total energy consumption",
@@ -835,5 +856,17 @@ ARISTON_SELECT_TYPES: list[AristonSelectEntityDescription] = (
             option
         ),
         system_types=[SystemType.GALEVO],
+    ),
+    AristonSelectEntityDescription(
+        key="Operation mode",
+        name=f"{NAME} Operation mode",
+        icon="mdi:cog",
+        entity_category=EntityCategory.CONFIG,
+        get_current_option=lambda entity: entity.device.water_heater_current_mode_text,
+        get_options=lambda entity: entity.device.water_heater_mode_operation_texts,
+        select_option=lambda entity, option: entity.device.async_set_water_heater_operation_mode(
+            option
+        ),
+        system_types=[SystemType.VELIS],
     ),
 )


### PR DESCRIPTION
Hello everyone. I made some changes, tested for about a month on my Lydos Hybrid Wifi on which they work and do not create problems.

1. Create "Operation mode" select entity for Lydos Hybrid:
    ![Screenshot 2024-01-05 at 18-48-17 Panoramica – Home Assistant](https://github.com/mauriziosacca/ariston-remotethermo-home-assistant-v3/assets/76613973/29485ba9-46b8-4a83-b5bd-c18709593a03)
    useful for quickly changing the operating mode and, if recording is activated, having a history of the operating mode;

2. Create "Current temperature" and "Target temperature" sensor entities:
    ![Screenshot 2024-01-05 at 18-47-58 Panoramica – Home Assistant](https://github.com/mauriziosacca/ariston-remotethermo-home-assistant-v3/assets/76613973/e0f53a2f-c6b6-45ba-a461-b4d87f0fb5a3)
    allows to view temperatures where Water Heater entity attributes cannot be used;

3. Add "hvac_action" attribute to the Water Heater entity:
    ![Screenshot 2024-01-05 at 18-47-40 Panoramica – Home Assistant](https://github.com/mauriziosacca/ariston-remotethermo-home-assistant-v3/assets/76613973/76fc4f81-b6e6-43b4-8369-0510f994e85b)
    ![Screenshot 2024-01-05 at 19-06-54 Panoramica – Home Assistant](https://github.com/mauriziosacca/ariston-remotethermo-home-assistant-v3/assets/76613973/b19ccb22-a8f7-494a-96fe-0d05cab2876e)
shows the current status of the Water Heater, "heating" or "idle", changing icon color accordingly.


I think they don't cause problems on other models, and that other users will find these changes useful.